### PR TITLE
🍱 Improve regex

### DIFF
--- a/src/main/java/fr/nethermc/socialcommands/regexs/Regexs.java
+++ b/src/main/java/fr/nethermc/socialcommands/regexs/Regexs.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class Regexs {
 
-    public static final String DISCORD_REGEX = "(discord\\.(gg|io)\\/)?([a-zA-Z0-9]+)";
+    public static final String DISCORD_REGEX = "(discord\\.(gg|io|com\/invite\/)\\/)?([a-zA-Z0-9]+)";
     public static final String TWITTER_REGEX = "(\\@)?([a-zA-Z0-9_]+)";
     public static final String INSTAGRAM_REGEX = "(\\@)?([a-zA-Z0-9_]+)";
     public static final String WEBSITE_REGEX = "(https?\\:(\\/\\/)?)?(([a-z\\.]+)\\.)?(([a-z]+)\\.([a-z]+))(\\/([a-zA-Z0-9_\\-\\.]+)?)?";


### PR DESCRIPTION
Sometimes, Discord links starts with "https://discord.com/invite/(code)". So, I improved regex.
I'm not familiar with java regex so... it will maybe need to be fixed.